### PR TITLE
feat(rfc_tools): implement RFC linter CLI

### DIFF
--- a/bin/rfc_lint.dart
+++ b/bin/rfc_lint.dart
@@ -1,0 +1,113 @@
+// Copyright 2026 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:file/local.dart';
+import 'package:rfc_tools/src/git_lister.dart';
+import 'package:rfc_tools/src/github_client.dart';
+import 'package:rfc_tools/src/linter.dart';
+import 'package:rfc_tools/src/taxonomy.dart';
+
+void main(List<String> arguments) async {
+  final parser = ArgParser()
+    ..addMultiOption(
+      'labels',
+      help: 'Comma-separated list of GitHub Pull Request labels.',
+    )
+    ..addFlag(
+      'enforce-drafts',
+      negatable: false,
+      help:
+          'Enforce that RFCs under review must use ".0000" unless labeled with "rfc-ready" or "rfc-assigned".',
+    )
+    ..addFlag(
+      'validate-github-users',
+      negatable: false,
+      help: 'Verify that GitHub profile authors exist via the GitHub API.',
+    )
+    ..addFlag(
+      'github-actions',
+      negatable: false,
+      help:
+          'Output errors in GitHub Actions annotation format (::error file=...::).',
+    )
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Show usage instructions.',
+    );
+
+  ArgResults results;
+  try {
+    results = parser.parse(arguments);
+  } catch (e) {
+    stderr.writeln('Error parsing arguments: $e\n');
+    stderr.writeln(parser.usage);
+    exit(1);
+  }
+
+  if (results.flag('help')) {
+    stdout.writeln('RFC Linter - Flutter RFC Repository Tooling\n');
+    stdout.writeln(parser.usage);
+    exit(0);
+  }
+
+  final enforceDrafts = results.flag('enforce-drafts');
+  final validateGitHubUsers = results.flag('validate-github-users');
+  final githubActions = results.flag('github-actions');
+
+  final labels = <String>{
+    for (var label in results.multiOption('labels'))
+      if (label.trim() case final trimmed when trimmed.isNotEmpty) trimmed,
+  };
+
+  const fs = LocalFileSystem();
+  const gh = CliGitHubClient();
+
+  Taxonomy taxonomy;
+  try {
+    taxonomy = await Taxonomy.load(fs);
+  } catch (e) {
+    stderr.writeln('Failed to load taxonomy: $e');
+    exit(1);
+  }
+
+  final filesOnMain = await defaultGitList(baseBranch: 'origin/main');
+
+  final linter = RfcLinter(
+    fs: fs,
+    gh: gh,
+    taxonomy: taxonomy,
+    labels: labels,
+    validateGitHubUsers: validateGitHubUsers,
+    existingFilesOnMain: filesOnMain,
+    enforceDrafts: enforceDrafts,
+  );
+
+  final issues = <LintIssue>[];
+  if (results.rest.isNotEmpty) {
+    for (final path in results.rest) {
+      issues.addAll(await linter.lintFile(fs.file(path)));
+    }
+  } else {
+    issues.addAll(await linter.lintDirectory(fs.directory('rfc')));
+  }
+
+  if (issues.isNotEmpty) {
+    stderr.writeln('RFC Lint failed with ${issues.length} issue(s):\n');
+    for (final issue in issues) {
+      if (githubActions) {
+        stderr.writeln(issue.toGithubAnnotation());
+      } else {
+        stderr.writeln('[ERROR] $issue');
+      }
+    }
+    exit(1);
+  }
+
+  stdout.writeln('All RFC documents passed lint checks cleanly.');
+  exit(0);
+}

--- a/bin/rfc_lint.dart
+++ b/bin/rfc_lint.dart
@@ -46,13 +46,14 @@ void main(List<String> arguments) async {
   } catch (e) {
     stderr.writeln('Error parsing arguments: $e\n');
     stderr.writeln(parser.usage);
-    exit(1);
+    exitCode = 1;
+    return;
   }
 
   if (results.flag('help')) {
     stdout.writeln('RFC Linter - Flutter RFC Repository Tooling\n');
     stdout.writeln(parser.usage);
-    exit(0);
+    return;
   }
 
   final enforceDrafts = results.flag('enforce-drafts');
@@ -72,7 +73,8 @@ void main(List<String> arguments) async {
     taxonomy = await Taxonomy.load(fs);
   } catch (e) {
     stderr.writeln('Failed to load taxonomy: $e');
-    exit(1);
+    exitCode = 1;
+    return;
   }
 
   final filesOnMain = await defaultGitList(baseBranch: 'origin/main');
@@ -105,9 +107,9 @@ void main(List<String> arguments) async {
         stderr.writeln('[ERROR] $issue');
       }
     }
-    exit(1);
+    exitCode = 1;
+    return;
   }
 
   stdout.writeln('All RFC documents passed lint checks cleanly.');
-  exit(0);
 }

--- a/bin/rfc_lint.dart
+++ b/bin/rfc_lint.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 The Flutter Authors. All rights reserved.
+// Copyright 2026 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/bin/rfc_lint.dart
+++ b/bin/rfc_lint.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:file/local.dart';
 import 'package:rfc_tools/src/git_lister.dart';
-import 'package:rfc_tools/src/github_client.dart';
 import 'package:rfc_tools/src/linter.dart';
 import 'package:rfc_tools/src/taxonomy.dart';
 
@@ -23,15 +22,15 @@ void main(List<String> arguments) async {
           'Enforce that RFCs under review must use ".0000" unless labeled with "rfc-ready" or "rfc-assigned".',
     )
     ..addFlag(
-      'validate-github-users',
-      negatable: false,
-      help: 'Verify that GitHub profile authors exist via the GitHub API.',
-    )
-    ..addFlag(
       'github-actions',
       negatable: false,
       help:
           'Output errors in GitHub Actions annotation format (::error file=...::).',
+    )
+    ..addOption(
+      'base-branch',
+      defaultsTo: 'origin/main',
+      help: 'Base branch to list files against',
     )
     ..addFlag(
       'help',
@@ -57,7 +56,6 @@ void main(List<String> arguments) async {
   }
 
   final enforceDrafts = results.flag('enforce-drafts');
-  final validateGitHubUsers = results.flag('validate-github-users');
   final githubActions = results.flag('github-actions');
 
   final labels = <String>{
@@ -66,7 +64,6 @@ void main(List<String> arguments) async {
   };
 
   const fs = LocalFileSystem();
-  const gh = CliGitHubClient();
 
   Taxonomy taxonomy;
   try {
@@ -77,26 +74,24 @@ void main(List<String> arguments) async {
     return;
   }
 
-  final filesOnMain = await defaultGitList(baseBranch: 'origin/main');
+  final filesOnMain = await defaultGitList(
+    baseBranch: results.option('base-branch')!,
+  );
 
   final linter = RfcLinter(
     fs: fs,
-    gh: gh,
     taxonomy: taxonomy,
     labels: labels,
-    validateGitHubUsers: validateGitHubUsers,
     existingFilesOnMain: filesOnMain,
     enforceDrafts: enforceDrafts,
   );
 
-  final issues = <LintIssue>[];
-  if (results.rest.isNotEmpty) {
-    for (final path in results.rest) {
-      issues.addAll(await linter.lintFile(fs.file(path)));
-    }
-  } else {
-    issues.addAll(await linter.lintDirectory(fs.directory('rfc')));
-  }
+  final issues = <LintIssue>[
+    if (results.rest.isNotEmpty)
+      for (final path in results.rest) ...await linter.lintFile(fs.file(path))
+    else
+      ...await linter.lintDirectory(fs.directory('rfc')),
+  ];
 
   if (issues.isNotEmpty) {
     stderr.writeln('RFC Lint failed with ${issues.length} issue(s):\n');

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -166,7 +166,7 @@ class RfcLinter {
     }
 
     final fm = rfc.frontmatter;
-    final rfcId = fm?.rfc ?? rfc.frontmatterRfc;
+    final rfcId = fm?.rfc;
     final expectedId = rfc.rfcId;
 
     if (rfcId != null && rfcId != expectedId) {
@@ -220,7 +220,7 @@ class RfcLinter {
         );
       }
 
-      final fmTitle = fm?.title.trim() ?? rfc.frontmatterTitle?.trim();
+      final fmTitle = fm?.title.trim();
       if (fmTitle != null &&
           fmTitle.isNotEmpty &&
           rfc.firstHeadingTitle != fmTitle) {

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -1,0 +1,262 @@
+// Copyright 2026 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
+
+import 'github_client.dart';
+import 'models/rfc_file.dart';
+import 'taxonomy.dart';
+
+/// A lint issue discovered in an RFC document.
+class LintIssue {
+  final String filePath;
+  final int line;
+  final int column;
+  final String message;
+
+  const LintIssue({
+    required this.filePath,
+    required this.message,
+    this.line = 1,
+    this.column = 1,
+  });
+
+  /// Formats the issue as a GitHub Actions workflow annotation.
+  ///
+  /// Percent-encodes special characters (%, \r, \n) per GitHub Actions workflow
+  /// command specifications so multiline schema templates are preserved cleanly.
+  String toGithubAnnotation() {
+    final encoded = message
+        .replaceAll('%', '%25')
+        .replaceAll('\r', '%0D')
+        .replaceAll('\n', '%0A');
+    return '::error file=$filePath,line=$line,col=$column::$encoded';
+  }
+
+  @override
+  String toString() => '$filePath:$line:$column: $message';
+}
+
+/// Linter enforcing RFC structure, metadata, taxonomy, and number allocation rules.
+class RfcLinter {
+  final FileSystem fs;
+  final GitHubClient gh;
+  final Taxonomy taxonomy;
+  final Set<String> labels;
+  final bool validateGitHubUsers;
+  final Set<String> existingFilesOnMain;
+  final bool enforceDrafts;
+
+  RfcLinter({
+    required this.fs,
+    required this.gh,
+    required this.taxonomy,
+    this.labels = const <String>{},
+    this.validateGitHubUsers = false,
+    this.existingFilesOnMain = const <String>{},
+    this.enforceDrafts = false,
+  });
+
+  /// Lints a single RFC file.
+  Future<List<LintIssue>> lintFile(File file) async {
+    final issues = <LintIssue>[];
+    final relativePath = file.path;
+
+    if (!await file.exists()) {
+      issues.add(LintIssue(filePath: relativePath, message: 'File not found.'));
+      return issues;
+    }
+
+    final content = await file.readAsString();
+    final rfc = RfcFile.parse(content, path: file.path);
+    final fileName = p.basename(file.path);
+
+    // 1. Filename & Path Validation
+    if (!rfc.hasValidFilename) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 1,
+          message:
+              'Filename "$fileName" does not match required format "AAA.NNNN-<slug>.md" '
+              '(where AAA is 3 digits, NNNN is 4 digits, and slug is lowercase kebab-case).',
+        ),
+      );
+      return issues; // Cannot perform further structural checks reliably
+    }
+
+    // 2. Taxonomy Validation
+    if (!taxonomy.isValidCategory(rfc.category!)) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 1,
+          message:
+              'Subsystem category "${rfc.category}" is not defined in the architecture taxonomy. '
+              'See rfc/000.0001-flutter-architecture-and-reference-taxonomy.md.',
+        ),
+      );
+    }
+
+    // 3. Draft vs Assigned Number Enforcement (PR Context)
+    if (enforceDrafts) {
+      final existingBasenames = existingFilesOnMain.map(p.basename).toSet();
+      final isExistingOnMain = existingBasenames.contains(fileName);
+      const bootstrapRfcs = {'000.0001', '000.0002'};
+      final isBootstrap = bootstrapRfcs.contains(rfc.rfcId);
+
+      if (!rfc.isDraft && !isExistingOnMain && !isBootstrap) {
+        final hasReadyOrAssigned =
+            labels.contains('rfc-ready') || labels.contains('rfc-assigned');
+        if (!hasReadyOrAssigned) {
+          issues.add(
+            LintIssue(
+              filePath: relativePath,
+              line: 1,
+              message:
+                  'RFC has assigned number "${rfc.rfcId}", but PR does not have '
+                  '"rfc-ready" or "rfc-assigned" label. RFCs under review must use index "0000".',
+            ),
+          );
+        }
+      }
+    }
+
+    // 4. YAML Frontmatter Validation
+    if (!rfc.hasFrontmatter) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 1,
+          message:
+              '${rfc.frontmatterError ?? 'Missing YAML frontmatter block.'}\n\n'
+              'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
+        ),
+      );
+      return issues;
+    }
+
+    if (rfc.frontmatterError != null) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 1,
+          message:
+              '${rfc.frontmatterError!}\n\n'
+              'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
+        ),
+      );
+      return issues;
+    }
+
+    if (rfc.frontmatterErrors.isNotEmpty) {
+      for (final err in rfc.frontmatterErrors) {
+        issues.add(LintIssue(filePath: relativePath, line: 2, message: err));
+      }
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 2,
+          message:
+              'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
+        ),
+      );
+    }
+
+    final fm = rfc.frontmatter;
+    final rfcId = fm?.rfc ?? rfc.frontmatterRfc;
+    final expectedId = rfc.rfcId;
+
+    if (rfcId != null && rfcId != expectedId) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 2,
+          message:
+              'Frontmatter "rfc" value ("$rfcId") does not match filename identifier ("$expectedId").',
+        ),
+      );
+    }
+
+    // GitHub author existence verification (if enabled)
+    if (validateGitHubUsers && fm != null) {
+      for (final author in fm.authors) {
+        if (author is GitHubAuthor) {
+          final exists = await gh.userExists(author.username);
+          if (!exists) {
+            issues.add(
+              LintIssue(
+                filePath: relativePath,
+                line: 2,
+                message: 'GitHub user "${author.username}" does not exist.',
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    // 5. First Heading Validation
+    if (rfc.firstHeading == null) {
+      issues.add(
+        LintIssue(
+          filePath: relativePath,
+          line: 1,
+          message:
+              'Document must contain a top-level heading matching "# RFC ${rfc.rfcId}: <Title>".',
+        ),
+      );
+    } else {
+      if (rfc.firstHeadingId != expectedId) {
+        issues.add(
+          LintIssue(
+            filePath: relativePath,
+            line: rfc.firstHeadingLine ?? 1,
+            message:
+                'First heading RFC identifier ("${rfc.firstHeadingId}") does not match "$expectedId".',
+          ),
+        );
+      }
+
+      final fmTitle = fm?.title.trim() ?? rfc.frontmatterTitle?.trim();
+      if (fmTitle != null &&
+          fmTitle.isNotEmpty &&
+          rfc.firstHeadingTitle != fmTitle) {
+        issues.add(
+          LintIssue(
+            filePath: relativePath,
+            line: rfc.firstHeadingLine ?? 1,
+            message:
+                'First heading title ("${rfc.firstHeadingTitle}") does not match frontmatter title ("$fmTitle").',
+          ),
+        );
+      }
+    }
+
+    return issues;
+  }
+
+  /// Lints all RFC markdown files in the specified directory.
+  Future<List<LintIssue>> lintDirectory(Directory dir) async {
+    final issues = <LintIssue>[];
+    if (!await dir.exists()) {
+      issues.add(
+        LintIssue(filePath: dir.path, message: 'Directory does not exist.'),
+      );
+      return issues;
+    }
+
+    final entries = await dir.list().toList();
+    entries.sort((a, b) => a.path.compareTo(b.path));
+
+    for (final entry in entries) {
+      if (entry is File && entry.path.endsWith('.md')) {
+        issues.addAll(await lintFile(entry));
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 The Flutter Authors. All rights reserved.
+// Copyright 2026 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -118,44 +118,23 @@ class RfcLinter {
     }
 
     // 4. YAML Frontmatter Validation
-    if (!rfc.hasFrontmatter) {
-      issues.add(
-        LintIssue(
-          filePath: relativePath,
-          line: 1,
-          message:
-              '${rfc.frontmatterError ?? 'Missing YAML frontmatter block.'}\n\n'
-              'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
-        ),
-      );
-      return issues;
-    }
-
-    if (rfc.frontmatterError != null) {
-      issues.add(
-        LintIssue(
-          filePath: relativePath,
-          line: 1,
-          message:
-              '${rfc.frontmatterError!}\n\n'
-              'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
-        ),
-      );
-      return issues;
-    }
-
     if (rfc.frontmatterErrors.isNotEmpty) {
-      for (final err in rfc.frontmatterErrors) {
-        issues.add(LintIssue(filePath: relativePath, line: 2, message: err));
+      for (final (:line, :error) in rfc.frontmatterErrors) {
+        issues.add(
+          LintIssue(filePath: relativePath, line: line, message: error),
+        );
       }
       issues.add(
         LintIssue(
           filePath: relativePath,
-          line: 2,
+          line: rfc.hasFrontmatter ? 2 : 1,
           message:
               'Expected frontmatter format:\n${RfcFrontmatter.expectedSchemaTemplate.trimRight()}',
         ),
       );
+      if (!rfc.hasFrontmatter) {
+        return issues;
+      }
     }
 
     final fm = rfc.frontmatter;

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -51,7 +51,9 @@ class RfcLinter {
     this.labels = const <String>{},
     this.enforceDrafts = false,
     Set<String> existingFilesOnMain = const <String>{},
-  }) : existingBasenames = {...existingFilesOnMain.map(p.basename)};
+  }) : existingBasenames = {
+         for (final file in existingFilesOnMain) p.basename(file),
+       };
 
   /// Lints a single RFC file.
   Future<List<LintIssue>> lintFile(File file) async {

--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -4,8 +4,6 @@
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
-
-import 'github_client.dart';
 import 'models/rfc_file.dart';
 import 'taxonomy.dart';
 
@@ -42,22 +40,18 @@ class LintIssue {
 /// Linter enforcing RFC structure, metadata, taxonomy, and number allocation rules.
 class RfcLinter {
   final FileSystem fs;
-  final GitHubClient gh;
   final Taxonomy taxonomy;
   final Set<String> labels;
-  final bool validateGitHubUsers;
-  final Set<String> existingFilesOnMain;
+  final Set<String> existingBasenames;
   final bool enforceDrafts;
 
   RfcLinter({
     required this.fs,
-    required this.gh,
     required this.taxonomy,
     this.labels = const <String>{},
-    this.validateGitHubUsers = false,
-    this.existingFilesOnMain = const <String>{},
     this.enforceDrafts = false,
-  });
+    Set<String> existingFilesOnMain = const <String>{},
+  }) : existingBasenames = {...existingFilesOnMain.map(p.basename)};
 
   /// Lints a single RFC file.
   Future<List<LintIssue>> lintFile(File file) async {
@@ -102,7 +96,6 @@ class RfcLinter {
 
     // 3. Draft vs Assigned Number Enforcement (PR Context)
     if (enforceDrafts) {
-      final existingBasenames = existingFilesOnMain.map(p.basename).toSet();
       final isExistingOnMain = existingBasenames.contains(fileName);
       const bootstrapRfcs = {'000.0001', '000.0002'};
       final isBootstrap = bootstrapRfcs.contains(rfc.rfcId);
@@ -178,24 +171,6 @@ class RfcLinter {
               'Frontmatter "rfc" value ("$rfcId") does not match filename identifier ("$expectedId").',
         ),
       );
-    }
-
-    // GitHub author existence verification (if enabled)
-    if (validateGitHubUsers && fm != null) {
-      for (final author in fm.authors) {
-        if (author is GitHubAuthor) {
-          final exists = await gh.userExists(author.username);
-          if (!exists) {
-            issues.add(
-              LintIssue(
-                filePath: relativePath,
-                line: 2,
-                message: 'GitHub user "${author.username}" does not exist.',
-              ),
-            );
-          }
-        }
-      }
     }
 
     // 5. First Heading Validation

--- a/test/rfc_lint_test.dart
+++ b/test/rfc_lint_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 The Flutter Authors. All rights reserved.
+// Copyright 2026 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/test/rfc_lint_test.dart
+++ b/test/rfc_lint_test.dart
@@ -1,0 +1,411 @@
+// Copyright 2026 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:rfc_tools/src/github_client.dart';
+import 'package:rfc_tools/src/linter.dart';
+import 'package:rfc_tools/src/taxonomy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RfcLinter', () {
+    late MemoryFileSystem fs;
+    late FakeGitHubClient gh;
+    late Taxonomy taxonomy;
+
+    const validTaxonomy = '''
+# RFC 000.0001: Taxonomy
+### 000 – Meta
+* **000:** Meta
+### 100 – Core
+* **110:** Foundation
+''';
+
+    const validDoc = '''---
+type: rfc
+rfc: '110.0000'
+title: Sample Feature
+description: A great new feature for foundation.
+status: draft
+created: 2026-09-01T00:00:00Z
+updated: 2026-09-01T00:00:00Z
+tags:
+  - 110-foundation
+authors:
+  - https://github.com/octocat
+---
+
+# RFC 110.0000: Sample Feature
+
+## Overview
+Body content here.
+''';
+
+    setUp(() async {
+      fs = MemoryFileSystem();
+      gh = FakeGitHubClient(existingUsers: {'octocat'});
+      taxonomy = Taxonomy.fromMarkdown(validTaxonomy);
+      await fs.directory('rfc').create(recursive: true);
+    });
+
+    test('passes completely valid draft RFC in PR', () async {
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(validDoc);
+
+      final linter = RfcLinter(
+        fs: fs,
+        gh: gh,
+        taxonomy: taxonomy,
+        labels: <String>{}, // PR without any special labels
+        validateGitHubUsers: true,
+      );
+
+      final issues = await linter.lintFile(file);
+      expect(issues, isEmpty);
+    });
+
+    test('detects non-kebab-case slug', () async {
+      final file = fs.file('rfc/110.0000-Invalid_Slug.md');
+      await file.writeAsString(validDoc);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+
+      final issues = await linter.lintFile(file);
+      expect(issues, isNotEmpty);
+      expect(issues.first.message, contains('does not match required format'));
+    });
+
+    test('detects unknown category against taxonomy', () async {
+      final doc = validDoc
+          .replaceAll('110.0000', '999.0000')
+          .replaceAll('110-foundation', '999-unknown');
+      final file = fs.file('rfc/999.0000-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains('not defined in the architecture taxonomy'),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'enforces .0000 when rfc-ready/rfc-assigned is absent in PR',
+      () async {
+        final doc = validDoc.replaceAll('110.0000', '110.0042');
+        final file = fs.file('rfc/110.0042-sample-feature.md');
+        await file.writeAsString(doc);
+
+        final linter = RfcLinter(
+          fs: fs,
+          gh: gh,
+          taxonomy: taxonomy,
+          labels: <String>{}, // Missing rfc-ready and rfc-assigned
+          enforceDrafts: true,
+        );
+
+        final issues = await linter.lintFile(file);
+        expect(
+          issues.any(
+            (i) =>
+                i.message.contains('RFCs under review must use index "0000"'),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('allows .NNNN when rfc-assigned or rfc-ready is present', () async {
+      final doc = validDoc.replaceAll('110.0000', '110.0042');
+      final file = fs.file('rfc/110.0042-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linterReady = RfcLinter(
+        fs: fs,
+        gh: gh,
+        taxonomy: taxonomy,
+        labels: {'rfc-ready'},
+        enforceDrafts: true,
+      );
+      expect(await linterReady.lintFile(file), isEmpty);
+
+      final linterAssigned = RfcLinter(
+        fs: fs,
+        gh: gh,
+        taxonomy: taxonomy,
+        labels: {'rfc-assigned'},
+        enforceDrafts: true,
+      );
+      expect(await linterAssigned.lintFile(file), isEmpty);
+    });
+
+    test(
+      'allows .NNNN when enforceDrafts is false (standard mode or main)',
+      () async {
+        final doc = validDoc.replaceAll('110.0000', '110.0042');
+        final file = fs.file('rfc/110.0042-sample-feature.md');
+        await file.writeAsString(doc);
+
+        final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+
+        expect(await linter.lintFile(file), isEmpty);
+      },
+    );
+
+    test('validates GitHub username existence via fake client', () async {
+      final doc = validDoc.replaceAll('octocat', 'nonexistent-user');
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linter = RfcLinter(
+        fs: fs,
+        gh: gh,
+        taxonomy: taxonomy,
+        validateGitHubUsers: true,
+      );
+
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains(
+            'GitHub user "nonexistent-user" does not exist',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('detects missing required frontmatter fields', () async {
+      const missingType = '''---
+rfc: '110.0000'
+title: Test
+description: Test
+status: draft
+created: 2026-09-01T00:00:00Z
+updated: 2026-09-01T00:00:00Z
+tags: [110-foundation]
+authors: [https://github.com/octocat]
+---
+# RFC 110.0000: Test
+''';
+      final file = fs.file('rfc/110.0000-test.md');
+      await file.writeAsString(missingType);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains('Frontmatter "type" must be "rfc"'),
+        ),
+        isTrue,
+      );
+      expect(
+        issues.any((i) => i.message.contains('Expected frontmatter format:')),
+        isTrue,
+      );
+    });
+
+    test(
+      'reports multiple frontmatter errors together along with expected schema template',
+      () async {
+        const missingAuthorAndUpdated = '''---
+type: rfc
+rfc: '110.0000'
+title: Multiple Errors
+description: Missing author and updated timestamp.
+status: draft
+created: 2026-09-01T00:00:00Z
+tags: [110-foundation]
+---
+# RFC 110.0000: Multiple Errors
+''';
+        final file = fs.file('rfc/110.0000-multiple-errors.md');
+        await file.writeAsString(missingAuthorAndUpdated);
+
+        final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+        final issues = await linter.lintFile(file);
+
+        expect(
+          issues.any(
+            (i) => i.message.contains(
+              'Frontmatter "updated" must be an ISO 8601 UTC timestamp.',
+            ),
+          ),
+          isTrue,
+        );
+        expect(
+          issues.any(
+            (i) => i.message.contains(
+              'Frontmatter "authors" must be a non-empty list of authors.',
+            ),
+          ),
+          isTrue,
+        );
+        expect(
+          issues.any((i) => i.message.contains('Expected frontmatter format:')),
+          isTrue,
+        );
+      },
+    );
+
+    test('detects heading title mismatch', () async {
+      const headingMismatch = '''---
+type: rfc
+rfc: '110.0000'
+title: Real Title
+description: Test
+status: draft
+created: 2026-09-01T00:00:00Z
+updated: 2026-09-01T00:00:00Z
+tags: [110-foundation]
+authors: [https://github.com/octocat]
+---
+# RFC 110.0000: Mismatched Title
+''';
+      final file = fs.file('rfc/110.0000-test.md');
+      await file.writeAsString(headingMismatch);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any((i) => i.message.contains('First heading title')),
+        isTrue,
+      );
+    });
+
+    test('detects empty items in frontmatter tags', () async {
+      final doc = validDoc.replaceAll(
+        'tags:\n  - 110-foundation',
+        'tags: [""]',
+      );
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains(
+            'Frontmatter "tags" items must be non-empty strings',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('detects frontmatter rfc mismatch with filename identifier', () async {
+      final doc = validDoc.replaceAll("rfc: '110.0000'", "rfc: '110.0001'");
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains(
+            'Frontmatter "rfc" value ("110.0001") does not match filename identifier ("110.0000").',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('detects unclosed frontmatter', () async {
+      const unclosed = '''---
+type: rfc
+rfc: '110.0000'
+title: Unclosed
+# Missing closing delimiter
+''';
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(unclosed);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains('Unclosed YAML frontmatter delimiter'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('detects invalid non-UTC timestamp', () async {
+      final doc = validDoc.replaceAll(
+        'created: 2026-09-01T00:00:00Z',
+        'created: 2026-09-01 12:00:00',
+      );
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(doc);
+
+      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) => i.message.contains('must be an ISO 8601 UTC timestamp'),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'allows editing an existing RFC from main without PR labels',
+      () async {
+        final doc = validDoc.replaceAll('110.0000', '110.0001');
+        final file = fs.file('rfc/110.0001-sample-feature.md');
+        await file.writeAsString(doc);
+
+        final linter = RfcLinter(
+          fs: fs,
+          gh: gh,
+          taxonomy: taxonomy,
+          labels: <String>{}, // PR with no labels
+          existingFilesOnMain: {
+            'rfc/110.0001-sample-feature.md',
+          }, // Already merged on main!
+        );
+
+        final issues = await linter.lintFile(file);
+        expect(issues, isEmpty);
+      },
+    );
+
+    group('LintIssue', () {
+      test(
+        'toGithubAnnotation percent-encodes newlines and special characters',
+        () {
+          const template = '''
+Expected frontmatter format:
+type: rfc
+rfc: '000.0001'
+description: 100% complete
+''';
+          const issue = LintIssue(
+            filePath: 'rfc/110.0000-feature.md',
+            line: 2,
+            column: 1,
+            message: template,
+          );
+
+          final annotation = issue.toGithubAnnotation();
+          expect(annotation.contains('\n'), isFalse);
+          expect(annotation.contains('\r'), isFalse);
+          expect(
+            annotation,
+            startsWith('::error file=rfc/110.0000-feature.md,line=2,col=1::'),
+          );
+          expect(
+            annotation,
+            contains('Expected frontmatter format:%0Atype: rfc'),
+          );
+          expect(annotation, contains('100%25 complete'));
+        },
+      );
+    });
+  });
+}

--- a/test/rfc_lint_test.dart
+++ b/test/rfc_lint_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/memory.dart';
-import 'package:rfc_tools/src/github_client.dart';
 import 'package:rfc_tools/src/linter.dart';
 import 'package:rfc_tools/src/taxonomy.dart';
 import 'package:test/test.dart';
@@ -11,7 +10,6 @@ import 'package:test/test.dart';
 void main() {
   group('RfcLinter', () {
     late MemoryFileSystem fs;
-    late FakeGitHubClient gh;
     late Taxonomy taxonomy;
 
     const validTaxonomy = '''
@@ -44,7 +42,6 @@ Body content here.
 
     setUp(() async {
       fs = MemoryFileSystem();
-      gh = FakeGitHubClient(existingUsers: {'octocat'});
       taxonomy = Taxonomy.fromMarkdown(validTaxonomy);
       await fs.directory('rfc').create(recursive: true);
     });
@@ -55,10 +52,8 @@ Body content here.
 
       final linter = RfcLinter(
         fs: fs,
-        gh: gh,
         taxonomy: taxonomy,
         labels: <String>{}, // PR without any special labels
-        validateGitHubUsers: true,
       );
 
       final issues = await linter.lintFile(file);
@@ -69,7 +64,7 @@ Body content here.
       final file = fs.file('rfc/110.0000-Invalid_Slug.md');
       await file.writeAsString(validDoc);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
 
       final issues = await linter.lintFile(file);
       expect(issues, isNotEmpty);
@@ -83,7 +78,7 @@ Body content here.
       final file = fs.file('rfc/999.0000-sample-feature.md');
       await file.writeAsString(doc);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
 
       final issues = await linter.lintFile(file);
       expect(
@@ -103,7 +98,6 @@ Body content here.
 
         final linter = RfcLinter(
           fs: fs,
-          gh: gh,
           taxonomy: taxonomy,
           labels: <String>{}, // Missing rfc-ready and rfc-assigned
           enforceDrafts: true,
@@ -127,7 +121,6 @@ Body content here.
 
       final linterReady = RfcLinter(
         fs: fs,
-        gh: gh,
         taxonomy: taxonomy,
         labels: {'rfc-ready'},
         enforceDrafts: true,
@@ -136,7 +129,6 @@ Body content here.
 
       final linterAssigned = RfcLinter(
         fs: fs,
-        gh: gh,
         taxonomy: taxonomy,
         labels: {'rfc-assigned'},
         enforceDrafts: true,
@@ -151,34 +143,11 @@ Body content here.
         final file = fs.file('rfc/110.0042-sample-feature.md');
         await file.writeAsString(doc);
 
-        final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+        final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
 
         expect(await linter.lintFile(file), isEmpty);
       },
     );
-
-    test('validates GitHub username existence via fake client', () async {
-      final doc = validDoc.replaceAll('octocat', 'nonexistent-user');
-      final file = fs.file('rfc/110.0000-sample-feature.md');
-      await file.writeAsString(doc);
-
-      final linter = RfcLinter(
-        fs: fs,
-        gh: gh,
-        taxonomy: taxonomy,
-        validateGitHubUsers: true,
-      );
-
-      final issues = await linter.lintFile(file);
-      expect(
-        issues.any(
-          (i) => i.message.contains(
-            'GitHub user "nonexistent-user" does not exist',
-          ),
-        ),
-        isTrue,
-      );
-    });
 
     test('detects missing required frontmatter fields', () async {
       const missingType = '''---
@@ -196,7 +165,7 @@ authors: [https://github.com/octocat]
       final file = fs.file('rfc/110.0000-test.md');
       await file.writeAsString(missingType);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
@@ -227,7 +196,7 @@ tags: [110-foundation]
         final file = fs.file('rfc/110.0000-multiple-errors.md');
         await file.writeAsString(missingAuthorAndUpdated);
 
-        final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+        final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
         final issues = await linter.lintFile(file);
 
         expect(
@@ -270,7 +239,7 @@ authors: [https://github.com/octocat]
       final file = fs.file('rfc/110.0000-test.md');
       await file.writeAsString(headingMismatch);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any((i) => i.message.contains('First heading title')),
@@ -286,7 +255,7 @@ authors: [https://github.com/octocat]
       final file = fs.file('rfc/110.0000-sample-feature.md');
       await file.writeAsString(doc);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
@@ -303,7 +272,7 @@ authors: [https://github.com/octocat]
       final file = fs.file('rfc/110.0000-sample-feature.md');
       await file.writeAsString(doc);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
@@ -325,7 +294,7 @@ title: Unclosed
       final file = fs.file('rfc/110.0000-sample-feature.md');
       await file.writeAsString(unclosed);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
@@ -343,7 +312,7 @@ title: Unclosed
       final file = fs.file('rfc/110.0000-sample-feature.md');
       await file.writeAsString(doc);
 
-      final linter = RfcLinter(fs: fs, gh: gh, taxonomy: taxonomy);
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
@@ -362,7 +331,7 @@ title: Unclosed
 
         final linter = RfcLinter(
           fs: fs,
-          gh: gh,
+
           taxonomy: taxonomy,
           labels: <String>{}, // PR with no labels
           existingFilesOnMain: {

--- a/test/rfc_lint_test.dart
+++ b/test/rfc_lint_test.dart
@@ -298,11 +298,88 @@ title: Unclosed
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
-          (i) => i.message.contains('Unclosed YAML frontmatter delimiter'),
+          (i) =>
+              i.line == 1 &&
+              i.message.contains('Unclosed YAML frontmatter delimiter') &&
+              !i.message.contains('(error:'),
+        ),
+        isTrue,
+      );
+      expect(
+        issues.any(
+          (i) =>
+              i.line == 1 && i.message.contains('Expected frontmatter format:'),
         ),
         isTrue,
       );
     });
+
+    test('detects missing frontmatter delimiter', () async {
+      const noFm = '''
+# RFC 110.0000: No Frontmatter
+
+Body content here.
+''';
+      final file = fs.file('rfc/110.0000-sample-feature.md');
+      await file.writeAsString(noFm);
+
+      final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
+      final issues = await linter.lintFile(file);
+      expect(
+        issues.any(
+          (i) =>
+              i.line == 1 &&
+              i.message.contains(
+                'File does not start with YAML frontmatter delimiter `---`.',
+              ) &&
+              !i.message.contains('(error:'),
+        ),
+        isTrue,
+      );
+      expect(
+        issues.any(
+          (i) =>
+              i.line == 1 && i.message.contains('Expected frontmatter format:'),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'reports exact line numbers for frontmatter field schema errors',
+      () async {
+        // Line 1: ---
+        // Line 2: type: rfc
+        // Line 3: rfc: '110.0000'
+        // Line 4: title: Sample Feature
+        // Line 5: description: A great new feature for foundation.
+        // Line 6: status: invalid_status
+        // Line 7: created: 2026-09-01T00:00:00Z
+        // Line 8: updated: 2026-09-01T00:00:00Z
+        // Line 9: tags: [110-foundation]
+        // Line 10: authors: [https://github.com/octocat]
+        // Line 11: ---
+        final doc = validDoc.replaceAll(
+          'status: draft',
+          'status: invalid_status',
+        );
+        final file = fs.file('rfc/110.0000-sample-feature.md');
+        await file.writeAsString(doc);
+
+        final linter = RfcLinter(fs: fs, taxonomy: taxonomy);
+        final issues = await linter.lintFile(file);
+
+        final statusIssue = issues.firstWhere(
+          (i) => i.message.contains('Frontmatter "status" must be one of:'),
+        );
+        expect(statusIssue.line, equals(6));
+
+        final templateIssue = issues.firstWhere(
+          (i) => i.message.contains('Expected frontmatter format:'),
+        );
+        expect(templateIssue.line, equals(2));
+      },
+    );
 
     test('detects invalid non-UTC timestamp', () async {
       final doc = validDoc.replaceAll(
@@ -316,7 +393,9 @@ title: Unclosed
       final issues = await linter.lintFile(file);
       expect(
         issues.any(
-          (i) => i.message.contains('must be an ISO 8601 UTC timestamp'),
+          (i) =>
+              i.line == 7 &&
+              i.message.contains('must be an ISO 8601 UTC timestamp'),
         ),
         isTrue,
       );


### PR DESCRIPTION
PR 4 of 7 for testing and automation

`RfcLint` and cli tool for enforcing document standards:

* `.0000` for drafts
* Validates category is valid and allocated.
* Kebab title format in file naming


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>