### PR TITLE
fix(actions): remove paths for merge queue / required checks

### DIFF
--- a/.github/workflows/rfc-lint.yml
+++ b/.github/workflows/rfc-lint.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - 'rfc/**'
   merge_group:
     types: [checks_requested]
   push:
@@ -15,6 +13,7 @@ on:
 
 jobs:
   lint-rfcs:
+    name: lint-rfcs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,13 +80,13 @@ jobs:
 
       - name: Markdown Lint (PR Mode)
         if: github.event_name == 'pull_request' && steps.changed-rfcs.outputs.has_changes == 'true'
-        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
+        uses: davidanson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
         with:
           globs: ${{ steps.changed-rfcs.outputs.files }}
 
       - name: Markdown Lint (Full Repository)
         if: github.event_name != 'pull_request'
-        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
+        uses: davidanson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
         with:
           globs: 'rfc/**/*.md'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,7 @@ name: Dart CI
 
 on:
   pull_request:
-    paths:
-      - 'lib/**'
-      - 'bin/**'
-      - 'test/**'
-      - 'pubspec.yaml'
-      - 'pubspec.lock'
-      - 'analysis_options.yaml'
-      - '.github/workflows/test.yml'
+    branches: [main]
   merge_group:
     types: [checks_requested]
   push:

--- a/.github/workflows/validate-rfc-number.yml
+++ b/.github/workflows/validate-rfc-number.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-    paths:
-      - 'rfc/**'
   merge_group:
     types: [checks_requested]
   push:


### PR DESCRIPTION
With required checks, you could get an action that deadlocks because it doesn't trip the "paths" check.